### PR TITLE
Fix: impossible to join a new group

### DIFF
--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -49,6 +49,6 @@ export const filteredSubjects = (state, getters) => getters.subjects.filter(subj
 export const joinedChannels = (state, getters) =>
   getters.channels.filter(channel => !channel.collaborators || !!channel.collaborators.find(collaborator => collaborator.email === state.collaborator.email))
 export const unjoinedChannels = (state, getters) =>
-  getters.channels.filter(channel => !channel.collaborators.find(collaborator => collaborator.email === state.collaborator.email))
+  getters.channels.filter(channel => channel.collaborators && !channel.collaborators.find(collaborator => collaborator.email === state.collaborator.email))
 
 export const notifications = state => state.notifications


### PR DESCRIPTION
js error, trying access a function on undefined.
Some channels don't have any collaborators: the seeded ones.

Unjoined channels are now displayed and therefore available to join.